### PR TITLE
Update the tensorflow version for Docker image to 1.14.0

### DIFF
--- a/{{cookiecutter.project_name}}/Keras_Tensorflow/03_BuildImage.ipynb
+++ b/{{cookiecutter.project_name}}/Keras_Tensorflow/03_BuildImage.ipynb
@@ -85,7 +85,7 @@
    "outputs": [],
    "source": [
     "# create yml file to be used in the image\n",
-    "conda_pack = [\"tensorflow-gpu==1.10.0\"]\n",
+    "conda_pack = [\"tensorflow-gpu==1.14.0\"]\n",
     "requirements = [\"keras==2.2.0\",\"Pillow==5.2.0\", \"azureml-defaults\", \"azureml-contrib-services\" ,\"toolz==0.9.0\"] \n",
     "\n",
     "imgenv = CondaDependencies.create(conda_packages=conda_pack,pip_packages=requirements)\n",


### PR DESCRIPTION
Need to update the tensorflow version for docker image to 1.14.0. Setting it to 1.10.0 as it was does not utilize the GPU once deployed.